### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.klettres.json
+++ b/org.kde.klettres.json
@@ -13,6 +13,16 @@
         "--socket=pulseaudio",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "/share/qlogging-categories6",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "phonon",


### PR DESCRIPTION
The installed size reduced from 68.4 MB to 61.9 MB MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.